### PR TITLE
Fix typos across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dependency management as possible, in an easy way, so your focus can be on just 
 ## Why Use Tool Manager?
 Developers often accumulate many shell scripts or small CLI tools over time. 
 
-We basically got bored trying to remember where our scripts were, managing dependencies, having to choose a particular language, configuration, hooking in to our bashrc, deciding how to back them up, share them etc. The focus shoud be on what we want the scripts to do, not the fluffing around. We also wanted to be able to choose the language best suited for the problem at hand, and be able to change our mind later. Also, as time went on, our small
+We basically got bored trying to remember where our scripts were, managing dependencies, having to choose a particular language, configuration, hooking in to our bashrc, deciding how to back them up, share them etc. The focus should be on what we want the scripts to do, not the fluffing around. We also wanted to be able to choose the language best suited for the problem at hand, and be able to change our mind later. Also, as time went on, our small
 bash script started to grow, and we wanted a way to cater for that growth.
 
 Tool Manager helps by addressing several common pain points:
@@ -73,7 +73,7 @@ or
   _include_once .my.common.sh  
 ```  
 
-  This will source the shared '@tm/lib.args.sh' library (@tm is the toolmanager namespace), the '.my.common.sh' (which is relative to your current script), and a thirdparty plugins exported lib '@some-vendor/some-plugin/lib.foo.sh'. The current script directory issues are automatically taken care of.
+  This will source the shared '@tm/lib.args.sh' library (@tm is the toolmanager namespace), the '.my.common.sh' (which is relative to your current script), and a third-party plugin's exported lib '@some-vendor/some-plugin/lib.foo.sh'. The current script directory issues are automatically taken care of.
 
 
   You can also include your own plugins exported lib (in folder <plugin-home>/lib-shared) using a '@this'
@@ -88,7 +88,7 @@ or
 
   - lib.args.sh     - make it easy to parse commands line args, along with validation, help message generation etc
   - lib.logs.sh     - provide logging for scripts
-  - lib.cfg.sh      - provide script configutation management
+  - lib.cfg.sh      - provide script configuration management
   - lib.util.sh     - common bash enhancements (probably should be called lib.lang.sh)
   - lib.validate.sh - argument validation support 
   - lib.file.*.sh   - read/write various file formats

--- a/bin-internal/tm-run-script
+++ b/bin-internal/tm-run-script
@@ -49,7 +49,7 @@ export TM_PLUGIN_STATE_DIR="$plugin_state_dir"
 # ensure plugin's can call their own scripts, without the prefix. The plugin env variables (TM_PLUGIN_..) should still work
 # to pass the config around.
 # The 'bin-internal' are utility scripts for the plugin itself, which are not exposed to the user. This allows
-# for a clutter free bash auto complete, while giving plugins accesss to more tools
+# for a clutter-free bash auto complete, while giving plugins access to more tools
 export PATH="$TM_PLUGIN_HOME/bin-internal:$TM_PLUGIN_HOME/bin:$PATH"
 
 # pass the log settings along

--- a/bin/tm-dev-tests
+++ b/bin/tm-dev-tests
@@ -78,7 +78,7 @@ main() {
       (
         _info "--- Running tests in: $test_file ---"
         if [[ ! -x "$test_file" ]] && [[ "${auto_fix}" == "1" ]]; then
-            _info "fixing exectuable flag on '${test_file}'"
+            _info "fixing executable flag on '${test_file}'"
             chmod +x "$test_file" # auto set executable bit
         fi
         ( "$test_file" || failures=1 ) &
@@ -87,7 +87,7 @@ main() {
     else
       _info "--- Running tests in: $test_file ---"
       if [[ ! -x "$test_file" ]] && [[ "${auto_fix}" == "1" ]]; then
-          _info "fixing exectuable flag on '${test_file}'"
+          _info "fixing executable flag on '${test_file}'"
           chmod +x "$test_file" # auto set executable bit
       fi
       "$test_file" || failures=1

--- a/bin/tm-edit
+++ b/bin/tm-edit
@@ -5,7 +5,7 @@
 # Usage: tm-edit [plugin_basename] [editor_command]
 #
 # Arguments:
-#  $1 - plugin_basename: You can provide a partial plugin name and ths script will find the plugin
+#  $1 - plugin_basename: You can provide a partial plugin name and this script will find the plugin
 #  $2 -  editor_command: Optional. The editor command to use (e.g., "vi", "nano", "code").
 #                   Defaults to $EDITOR, then 'vi', then 'nano'.
 #

--- a/lib-shared/tm/bash/lib.args.sh
+++ b/lib-shared/tm/bash/lib.args.sh
@@ -18,7 +18,7 @@ _tm::source::include_once @tm/lib.validate.sh
 #   --ignore-spec-errors  : (optional) if set, ignore any parse args errors due to invalid option specs. It will still validate user input. Only affects options given after this option. Default 0
 #                       This can be useful if your scripts might encounter older versions of tool-manager
 #   --opt-<key> name/value pairs: '|name=value|name2=value2'.  The option specification. Used to tell the args parser what the user supplied options can be
-#                     First char is the value separator (non alpha-numeric, e.g '|' or ';' etc). Recommended to use '|'. This caters for 'special chars' in any of the values which
+#                     First char is the value separator (non alphanumeric, e.g '|' or ';' etc). Recommended to use '|'. This caters for 'special chars' in any of the values which
 #                     might clash with the separator if it were fixed. By forcing  it's use,it's clear
 #
 #                     e.g. ';short=x;desc=The value for 'x' can be a|b'
@@ -35,7 +35,7 @@ _tm::source::include_once @tm/lib.validate.sh
 #                    - desc          (optional) help text
 #                    - example       (optional) example text
 #                    - default       (optional) default value. The default is an empty string
-#                    - allowed       (optional) allowed values. First char is the value separator if non alpha-numeric. Default is ','. E.g. ,foo,bar or |foo|bar
+#                    - allowed       (optional) allowed values. First char is the value separator if non alphanumeric. Default is ','. E.g. ,foo,bar or |foo|bar
 #                    - validators|validator    (optional) comma separated validators
 #                                    (+alphanumeric,+numbers,+letters,+nowhitespace,+noslash,+re:<pattern>,plugin-vendor,plugin-name,plugin-prefix).
 #
@@ -52,7 +52,7 @@ _tm::source::include_once @tm/lib.validate.sh
 #   --help-tip               : (flag) if set, then always print a small help tip. Default is false
 #   --help-on-error          : (flag) if set, then print the help on validation error. Default is false
 #   --                       : Important! the separator to differentiate between the parser options and the caller args. User supplied args must come after this
-#   <user supplied args...>  : User supplied command-line arguments to parse (usign the above provided option specs as the rules)
+#   <user supplied args...>  : User supplied command-line arguments to parse (using the above provided option specs as the rules)
 #
 # Example:
 #   declare -A args
@@ -251,7 +251,7 @@ _tm::args::parse() {
     __print_help() {
         local bold=$(tput bold)
         local normal=$(tput sgr0)
-        # show the args passed if it's not just the help. THsi is helpful in case commands are called from within another program
+        # show the args passed if it's not just the help. This is helpful in case commands are called from within another program
         # and there is a failure
         if [[ ! "${user_args}" == '--help' ]] && [[ ! "${user_args}" == '-h' ]]; then
           __println "${bold}PROVIDED ARGS${normal}"

--- a/lib-shared/tm/bash/lib.cfg.sh
+++ b/lib-shared/tm/bash/lib.cfg.sh
@@ -434,7 +434,7 @@ _tm::cfg::__ensure_config_has_required_values(){
 
 #
 # Generate a hash unique for the given config files. If they change, so should the hash. It is not
-# cryptogrpahically secure, and it shold only be used for simple change detection
+# cryptographically secure, and it should only be used for simple change detection
 #
 _tm::cfg::__generate_hash_for(){
   local files=("$@") # All the passed in files

--- a/lib-shared/tm/bash/lib.log.sh
+++ b/lib-shared/tm/bash/lib.log.sh
@@ -1,5 +1,5 @@
 #
-# Library to provide logging (and stacktrace) related funtionality
+# Library to provide logging (and stacktrace) related functionality
 #
 
 if command -v _tm::log::set_opts &>/dev/null; then

--- a/lib-shared/tm/bash/lib.parse.sh
+++ b/lib-shared/tm/bash/lib.parse.sh
@@ -131,7 +131,7 @@ _tm::parse::git_url(){
 #   - `cfg_sh`: Path to the plugin's merged shell configuration file (to apply all the config)
 #   - `state_dir`: Path to the plugin's state dir (where it can save persistent state)
 #   - `cache_dir`: Path to the plugin's cache dir (where it can save cached data)
-#   - `packages_dir`: Path to the plugin's packaages dir (where it can install things to)
+#   - `packages_dir`: Path to the plugin's packages dir (where it can install things to)
 #   - `tm`: Boolean, true if this is the tool-manager plugin itself.
 #
 # Usage:
@@ -423,7 +423,7 @@ _tm::parse::__set_plugin_derived_vars(){
   result_ref_derived[cfg_spec]="${result_ref_derived[install_dir]}/plugin.cfg.yaml"
   result_ref_derived[cfg_dir]="$TM_PLUGINS_CFG_DIR/${qpath}"
   result_ref_derived[cfg_sh]="$TM_PLUGINS_CFG_DIR/${qpath}/config.sh" # plugin specific main config file
-  result_ref_derived[state_dir]="$TM_PLUGINS_STATE_DIR/${qpath}" # where the plugin should store persistant stae
+  result_ref_derived[state_dir]="$TM_PLUGINS_STATE_DIR/${qpath}" # where the plugin should store persistent state
   result_ref_derived[cache_dir]="$TM_PLUGINS_CACHE_DIR/${qpath}" # the plugins cache dir, for data that can be lost and regenerated
   result_ref_derived[packages_dir]="$TM_PLUGINS_PACKAGES_DIR/${qpath}" # where to install plugin specific deps/progs
 }

--- a/lib-shared/tm/bash/lib.script.sh
+++ b/lib-shared/tm/bash/lib.script.sh
@@ -1,5 +1,5 @@
 #
-# Scripts should generall source this script by default to include the common setup
+# Scripts should generally source this script by default to include the common setup
 #
 
 # make the scripts fail fast

--- a/lib-shared/tm/bash/lib.source.sh
+++ b/lib-shared/tm/bash/lib.source.sh
@@ -31,8 +31,8 @@ _include_once() {
 # by user scripts, in which case the entry point is the function, not the 'source path/to/this/script'
 # and hence we need to check the init was carried out.
 #
-# This is mor magic than most other functions, as it is assumed in other cases that the lib.log.sh and lib.source.sh
-# are loaded. However lib.source.sh can be invoked before everythign has been setup, so needs to be more aware of boot
+# This is more magic than most other functions, as it is assumed in other cases that the lib.log.sh and lib.source.sh
+# are loaded. However lib.source.sh can be invoked before everything has been setup, so needs to be more aware of boot
 # strapping sequencing and the like, and handle the case where not everything has been setup yet.
 #
 #

--- a/lib-shared/tm/bash/lib.util.sh
+++ b/lib-shared/tm/bash/lib.util.sh
@@ -374,7 +374,7 @@ _tm::util::array::get_first(){
       return
     fi
   done
-   _fail "Coud not find any values with keys matching one of ($@)"
+   _fail "Could not find any values with keys matching one of ($@)"
 }
 
 # Safe remove function that checks if a directory is not root and not empty


### PR DESCRIPTION
## Summary
- run codespell and fix typos across repo

## Testing
- `codespell -q 3`
- `bin/tm-dev-tests` *(fails: env-tm-bash not found)*
- `bin/tm-dev-shellcheck --severity error` *(fails: env-tm-bash not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b0578d348322b64ac89f276e3efb